### PR TITLE
Fixes for error handling and latest url

### DIFF
--- a/youtube_dl_gui/updatemanager.py
+++ b/youtube_dl_gui/updatemanager.py
@@ -39,7 +39,7 @@ class UpdateThread(Thread):
 
     """
 
-    LATEST_YOUTUBE_DL = 'https://yt-dl.org/latest/'
+    LATEST_YOUTUBE_DL = 'https://yt-dl.org/downloads/latest/'
     DOWNLOAD_TIMEOUT = 10
 
     def __init__(self, download_path, quiet=False):

--- a/youtube_dl_gui/updatemanager.py
+++ b/youtube_dl_gui/updatemanager.py
@@ -64,7 +64,7 @@ class UpdateThread(Thread):
 
             self._talk_to_gui('correct')
         except (HTTPError, URLError, IOError) as error:
-            self._talk_to_gui('error', unicode(error))
+            self._talk_to_gui('error', str(error))
 
         if not self.quiet:
             self._talk_to_gui('finish')


### PR DESCRIPTION
unicode() is now str() in python3. The url for youtube-dl has changed as well.

Now to figure out why I can't seem to package it using py2exe (unknown url type https) or pyinstaller (refuses to package wx)...